### PR TITLE
Laravel 5.6+ Support

### DIFF
--- a/src/ExpressionEngineHasher.php
+++ b/src/ExpressionEngineHasher.php
@@ -30,6 +30,17 @@ class ExpressionEngineHasher implements HasherContract{
      * @var int
      */
     protected $bcrypt_hash_size = 60;
+    
+    /**
+     * Get information about the given hashed value.
+     *
+     * @param  string $hashedValue
+     * @return array
+     */
+    public function info($hashedValue)
+    {
+        return password_get_info($hashedValue);
+    }
 
     /**
      * Hash the given value.


### PR DESCRIPTION
Support for Laravel 5.6+. Hasher interface now requires an info function. This was pulled from 'Illuminate\Hashing\AbstractHasher';